### PR TITLE
Simplify PipeIterate::execute()

### DIFF
--- a/src/PipeIterate.php
+++ b/src/PipeIterate.php
@@ -22,9 +22,6 @@ class PipeIterate implements PipeInterface
      */
     public function execute(Source $src)
     {
-        foreach ($src->getDistFiles() as $file) {
-            $callback = $this->callback;
-            $callback($file);
-        }
+        array_walk($src->getDistFiles(), $this->callback);
     }
 }


### PR DESCRIPTION
This pull request simplifies the `PipeIterate::execute()` method. No need for manual looping, and no need for another variable.