### PR TITLE
Phulp, the object-oriented way

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2,40 +2,37 @@
 
 ## Create your PhulpFile.php
 
-You must create a file called PhulpFile.php on your project root.
+You have to create a file called `PhulpFile.php` in your project root.
 
 ```php
 <?php
 ​
-use Phulp\Phulp;
-​
 // Define the default task
-Phulp::task('default', function () {
-    Phulp::start(['clean']);
+$phulp->task('default', function ($phulp) {
+    $phulp->start(['clean']);
 ​
     // Define the source folder
-    Phulp::src(['src/'], '/php$/', false)
-        ->pipe(Phulp::iterate(function ($distFile) {
+    $phulp->src(['src/'], '/php$/', false)
+        ->pipe($phulp->iterate(function ($distFile) {
             \Phulp\Output::out($distFile->getName(), 'blue');
         }))
-        ->pipe(Phulp::dest('dist/'));
+        ->pipe($phulp->dest('dist/'));
 });
 ​
 // Define the clean task
-Phulp::task('clean', function () {
-    Phulp::src(['dist/'])
-        ->pipe(Phulp::clean());
+$phulp->task('clean', function ($phulp) {
+    $phulp->src(['dist/'])
+        ->pipe($phulp->clean());
 });
 ​
 // Define the watch task
-Phulp::task('watch', function () {
+$phulp->task('watch', function ($phulp) {
     // Phulp will watch 'src' folder
-    Phulp::watch(
-        Phulp::src(['src/'], '/php$/', false),
+    $phulp->watch(
+        $phulp->src(['src/'], '/php$/', false),
         ['default']
     );
 });
-
 ```
 
 ## Run Phulp:
@@ -53,32 +50,30 @@ $ vendor/bin/phulp watch # Will run the `watch` task
 
 ## Methods
 
-### Phulp::task()
+### $phulp->task()
 
 Instantiate yours tasks.
 
 ```php
 <?php
 
-Phulp::task('name', function () {
+$phulp->task('name', function ($phulp) {
     // here your code
 });
-
 ```
 
-### Phulp::clean()
+### $phulp->clean()
 
-Return for you an instance of \Phulp\PipeIterate that will iterate all src files and delete your parent directory.
+Return for you an instance of `\Phulp\PipeIterate` that will iterate all src files and delete your parent directory.
 
 ```php
 <?php
 
-Phulp::src(['dist/'])
-    ->pipe(Phulp::clean());
-
+$phulp->src(['dist/'])
+    ->pipe($phulp->clean());
 ```
 
-### Phulp::src()
+### $phulp->src()
 
 Find files for manage them, and you can pipe them also.
 
@@ -87,11 +82,10 @@ Find files for manage them, and you can pipe them also.
 
 /**
  * 1st param required: array of directories
- * 2nd param not-required defualt null: pattern
- * 3th param not-required default true: boolean for recursion
+ * 2nd param not-required default '': pattern
+ * 3th param not-required default false: boolean for recursion
  */
-Phulp::src(['src/'], '/pattern/', false);
-
+$phulp->src(['src/'], '/pattern/', false);
 ```
 
 Piping:
@@ -99,60 +93,53 @@ Piping:
 ```php
 <?php
 
-Phulp::src(['src/'], '/pattern/', false)
+$phulp->src(['src/'], '/pattern/', false)
     // ->pipe(\Phulp\PipeInterface)
-
 ```
 
-### Phulp::iterate()
+### $phulp->iterate()
 
 Provide iteration with src files using clousure:
 
 ```php
 <?php
 
-Phulp::src(['src/'], '/pattern/', false)
-    ->pipe(Phulp::iterate(function ($distFile) {
-        /**
-         * @var \Phulp\DistFile $distFile
-         */
+$phulp->src(['src/'], '/pattern/', false)
+    ->pipe($phulp->iterate(function ($distFile) {
+        /** @var \Phulp\DistFile $distFile */
     }));
-
 ```
 
-### Phulp::dest()
+### $phulp->dest()
 
 Used to pipe src files and the src files will be placed for the directory passed as parameter in dest():
 
 ```php
 <?php
 
-Phulp::src(['src/'], '/pattern/', false)
-    ->pipe(Phulp::dest('dist/'))
-
+$phulp->src(['src/'], '/pattern/', false)
+    ->pipe($phulp->dest('dist/'))
 ```
 
-### Phulp::watch()
+### $phulp->watch()
 
 Watch files and do something when a file changes.
 
 ```php
 <?php
 
-Phulp::watch(
-    Phulp::src(['src/'], '/php$/', false),
+$phulp->watch(
+    $phulp->src(['src/'], '/php$/', false),
     ['default'] // The "default" task will be emited when the src was changed
 );
-
 ```
 
-### Phulp::start()
+### $phulp->start()
 
 Starts synchronously the tasks passed by parameter:
 
 ```php
 <?php
 
-Phulp::start(['default', 'watch']);
-
+$phulp->start(['default', 'watch']);
 ```

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -82,8 +82,8 @@ Find files for manage them, and you can pipe them also.
 
 /**
  * 1st param required: array of directories
- * 2nd param not-required default '': pattern
- * 3th param not-required default false: boolean for recursion
+ * 2nd param not-required default null: pattern
+ * 3th param not-required default true: boolean for recursion
  */
 $phulp->src(['src/'], '/pattern/', false);
 ```

--- a/README.md
+++ b/README.md
@@ -31,31 +31,32 @@ $ composer require reisraff/phulp:~0.0.3
 ```php
 <?php
 
-use Phulp\Phulp;
-
-Phulp::task('default', function () {
-    Phulp::start(['clean']);
-
-    Phulp::src(['src/'], '/php$/', false)
-        // ->pipe(\Phulp\PipeInterface)
-        ->pipe(Phulp::iterate(function ($distFile) {
+// Define the default task
+$phulp->task('default', function ($phulp) {
+    $phulp->start(['clean']);
+​
+    // Define the source folder
+    $phulp->src(['src/'], '/php$/', false)
+        ->pipe($phulp->iterate(function ($distFile) {
             \Phulp\Output::out($distFile->getName(), 'blue');
         }))
-        ->pipe(Phulp::dest('dist/'));
+        ->pipe($phulp->dest('dist/'));
 });
-
-Phulp::task('clean', function () {
-    Phulp::src(['dist/'])
-        ->pipe(Phulp::clean());
+​
+// Define the clean task
+$phulp->task('clean', function ($phulp) {
+    $phulp->src(['dist/'])
+        ->pipe($phulp->clean());
 });
-
-Phulp::task('watch', function () {
-    Phulp::watch(
-        Phulp::src(['src/'], '/php$/', false),
+​
+// Define the watch task
+$phulp->task('watch', function ($phulp) {
+    // Phulp will watch 'src' folder
+    $phulp->watch(
+        $phulp->src(['src/'], '/php$/', false),
         ['default']
     );
 });
-
 ```
 
 ##### Run:

--- a/bin/phulp.php
+++ b/bin/phulp.php
@@ -10,14 +10,13 @@ foreach (['../../../autoload.php', '../../autoload.php', '../vendor/autoload.php
 
 ini_set('register_argc_argv', true);
 
-$task = isset($argv[1]) ? $argv[1] : 'default';
-
 $phulpFile = './PhulpFile.php';
 if ( ! file_exists($phulpFile)) {
     Phulp\Output::out('The PhulpFile.php was not created.', 'red');
     return false;
 }
-require $phulpFile;
 
 $phulp = new Phulp\Phulp();
-$phulp->run($task);
+require $phulpFile;
+$phulp->run(isset($argv[1]) ? $argv[1] : 'default');
+unset($phulp);

--- a/src/Phulp.php
+++ b/src/Phulp.php
@@ -92,29 +92,16 @@ class Phulp
         return $this->iterate(function ($distFile) use ($path) {
             /** @var DistFile $distFile */
             $filename = $distFile->getDistpathname();
-            $relativepath = null;
-
-            if (strrpos($filename, DIRECTORY_SEPARATOR)) {
-                // TODO: Either remove this (as it is not used), or use it. :)
-                $filename = substr(
-                    $distFile->getDistpathname(),
-                    strrpos($distFile->getDistpathname(), DIRECTORY_SEPARATOR) + 1
-                );
-
-                $relativepath = substr(
-                    $distFile->getDistpathname(),
-                    0,
-                    strrpos($distFile->getDistpathname(), DIRECTORY_SEPARATOR)
-                );
-            }
-
-            $dir = $path . DIRECTORY_SEPARATOR . $relativepath;
-            if (!empty($relativepath) && !file_exists($dir)) {
-                mkdir($dir, 0777, true);
+            $dsPos = strrpos($filename, DIRECTORY_SEPARATOR);
+            if ($dsPos) {
+                $dir = $path . DIRECTORY_SEPARATOR . substr($filename, 0, $dsPos);
+                if (!file_exists($dir)) {
+                    mkdir($dir, 0777, true);
+                }
             }
 
             file_put_contents(
-                $path . DIRECTORY_SEPARATOR . $distFile->getDistpathname(),
+                $path . DIRECTORY_SEPARATOR . $filename,
                 $distFile->getContent()
             );
         });

--- a/src/Watch.php
+++ b/src/Watch.php
@@ -6,9 +6,9 @@ class Watch
 {
     /**
      * @param Source $src
-     * @param array $tasks
+     * @param callable $callback
      */
-    public function __construct(Source $src, array $tasks)
+    public function __construct(Source $src, callable $callback)
     {
         while (true) {
             foreach ($src->getDistFiles() as $distFile) {
@@ -30,7 +30,7 @@ class Watch
                             'yellow'
                         );
                         $distFile->setLastChangeTime($timeChange);
-                        Phulp::start($tasks);
+                        $callback();
                     }
                 }
             }


### PR DESCRIPTION
This pull request is not yet intended for merge, but should serve as a discussion platform. When merged, it fixes #11.

It (the pull request) includes:
- a refactored `Phulp` base class that:
  - doesn't use any (final) static methods or properties;
  - passes itself to the task callbacks;
  -passed the newly created `Watch` objects only the things they actually directly need;
- an adapted `bin/phulp.php` file;
- an adapted `Watch` class/constructor;
- adaptated versions of the `DOCUMENTATION.md` and `README.md` files.

There is [a TODO note in `Phulp::dest()`](https://github.com/reisraff/phulp/pull/14/files#diff-389a38f7e57a5cccdb6a170420f68bc0R98) that you might want to have a look at. I'm not completely sure what you were trying to do there, but the current code is either wrong or obsolete.

Interested in your opinions.