### PR TITLE
sets default working directory of Phulp::exec to getcwd()

### DIFF
--- a/src/Phulp.php
+++ b/src/Phulp.php
@@ -196,7 +196,7 @@ class Phulp
 
         $defaults = [
             'env' => null,
-            'cwd' => __DIR__ . '/../bin/',
+            'cwd' => getcwd(),
         ];
 
         $command = array_merge($defaults, $command);

--- a/test/PhulpTest.php
+++ b/test/PhulpTest.php
@@ -181,4 +181,29 @@ class PhulpTest extends TestCase
         $phulp = new Phulp;
         $phulp->start(['test']);
     }
+
+    /**
+     * @covers Phulp::exec
+     */
+    public function testExecDefaultWorkdingDirectory()
+    {
+        $phulp = new Phulp;
+        $result = $phulp->exec([
+            'command' => 'php -r "echo getcwd();"'
+        ]);
+        $this->assertSame(getcwd(), $result['output']);
+    }
+
+    /**
+     * @covers Phulp::exec
+     */
+    public function testExecSetWorkdingDirectory()
+    {
+        $phulp = new Phulp;
+        $result = $phulp->exec([
+            'command' => 'php -r "echo getcwd();"',
+            'cwd' => __DIR__
+        ]);
+        $this->assertSame(__DIR__, $result['output']);
+    }
 }


### PR DESCRIPTION
The current working directory "vendor/reisraff/phulp/bin" is not very practical. I would expect the working-directory to be the current directory, which should usually be the project root where phulp is run from.