### PR TITLE
Add function to use alias command

### DIFF
--- a/src/Phulp.php
+++ b/src/Phulp.php
@@ -201,6 +201,10 @@ class Phulp
 
         $command = array_merge($defaults, $command);
 
+        if ($command['env']['BASHRC_PATH']) {
+            $command['command'] = 'shopt -s expand_aliases;source $BASHRC_PATH;'."\n{$command['command']}";
+        }
+
         if ($async) {
             $process = new Process($command['command'], $command['cwd'], $command['env']);
             $process->start($this->getLoop());


### PR DESCRIPTION
Function add because alias command could not be used.

- [linux - How to create alias for bash inside php exec? - Stack Overflow](https://stackoverflow.com/questions/21839165/how-to-create-alias-for-bash-inside-php-exec "linux - How to create alias for bash inside php exec? - Stack Overflow")
- [alias - Why aliases in a non-interactive Bash shell do not work - Stack Overflow](https://stackoverflow.com/questions/1615877/why-aliases-in-a-non-interactive-bash-shell-do-not-work/1615973#1615973 "alias - Why aliases in a non-interactive Bash shell do not work - Stack Overflow")

Reason for setting environment variable to ``BASHRC_PATH``

- Because the behavior of the ``proc_open`` function was special.
- ``$CWD`` and ``$BASH`` are automatically loaded, but ``$HOME`` and ``$USER`` are not loaded.
- Even if it is not currently loaded, it may become readable after ``proc_open`` changes specifications.

For the above reasons, I prepared ``BASHRC_PATH``.
I thought about whether to use ``BASHRC_PATH`` or ``ALIAS_PATH``,
but I chose ``BASHRC_PATH`` because it is the path to ``.bashrc`` to specify.

Please tell me if there is a better way.
Thanks!
