### PR TITLE
fix custom vendor-dir

### DIFF
--- a/bin/phulp.php
+++ b/bin/phulp.php
@@ -3,8 +3,12 @@
 $version = '1.11.0';
 
 $files = ['../../../autoload.php', '../../autoload.php', '../vendor/autoload.php', 'vendor/autoload.php'];
+
+$vendor = exec('composer config vendor-dir');
+$files[] = "{$vendor}/autoload.php";
+
 foreach ($files as $autoload) {
-    $autoload = __DIR__ . '/' . $autoload;
+    $autoload = realpath($autoload);
     if (file_exists($autoload)) {
         require $autoload;
         break;

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "reisraff/phulp",
   "description": "The task manager for PHP",
   "type": "library",
+  "version": "1.11.0",
   "keywords": [
     "phulp",
     "php",


### PR DESCRIPTION
Fixed the problem which occurred in the following cases.
- ``vendor-dir`` is set.
- installing as a symbolic link.

composer.json

```
{
  "config": {
    "bin-dir": "$HOME/.composer/bin",
    "vendor-dir": "$HOME/.composer/vendor",
    "cache-dir": "$HOME/.composer/cache"
  },
  "repositories": [{
    "type": "path",
    "url": "$HOME/Scripts/phulp",
    "options": {
      "symlink": true
    }
  }],
  "require": {
    "reisraff/phulp": "*"
  }
}
```

When installing by specifying repositories path, it becomes an error if there is no version.
- [Repositories - Composer](https://getcomposer.org/doc/05-repositories.md#path "Repositories - Composer")

