### PR TITLE
fix composer not found

### DIFF
--- a/bin/phulp.php
+++ b/bin/phulp.php
@@ -9,7 +9,7 @@ if (file_exists($config)) {
     $json = file_get_contents($config);
     $json = json_decode($json, true);
     if (isset($json['config']['vendor-dir'])) {
-        $vendor = exec("echo " . $json['config']['vendor-dir']);
+        $vendor = exec('echo ' . $json['config']['vendor-dir']);
         if ($vendor) $files[] = "{$vendor}/autoload.php";
     }
 }

--- a/bin/phulp.php
+++ b/bin/phulp.php
@@ -4,8 +4,15 @@ $version = '1.11.0';
 
 $files = ['../../../autoload.php', '../../autoload.php', '../vendor/autoload.php', 'vendor/autoload.php'];
 
-$vendor = exec('composer config vendor-dir');
-$files[] = "{$vendor}/autoload.php";
+$config = getcwd() . '/composer.json';
+if (file_exists($config)) {
+    $json = file_get_contents($config);
+    $json = json_decode($json, true);
+    if (isset($json['config']['vendor-dir'])) {
+        $vendor = exec("echo " . $json['config']['vendor-dir']);
+        if ($vendor) $files[] = "{$vendor}/autoload.php";
+    }
+}
 
 foreach ($files as $autoload) {
     $autoload = realpath($autoload);


### PR DESCRIPTION
This is one of the contents I proposed.

- [\[Proposal\] Use phulp config file · Issue #41 · reisraff/phulp](https://github.com/reisraff/phulp/issues/41 "[Proposal] Use phulp config file · Issue #41 · reisraff/phulp")

----

If there is no ``composer`` command or it is an alias it will result in an error

- [macos - Installing composer on OSX with MAMP - Stack Overflow](https://stackoverflow.com/questions/30324042/installing-composer-on-osx-with-mamp "macos - Installing composer on OSX with MAMP - Stack Overflow")

```
$ phulp run
sh: composer: command not found
```

Instead of using the ``composer`` command, read values ​​directly from ``composer.json``.

```
{
  "name": "name",
  "description": "description",
  "config": {
    "bin-dir": "$HOME/.composer/bin",
    "vendor-dir": "$HOME/.composer/vendor",
    "cache-dir": "$HOME/.composer/cache"
  },
  "repositories": [{
  ...
}
```